### PR TITLE
persistent animation & different behaviour during hook execution issue #3

### DIFF
--- a/parrot.el
+++ b/parrot.el
@@ -76,8 +76,8 @@
          (set-default sym val)
          (parrot-refresh)))
 
-(defcustom parrot-persistant-animation-frame-interval 0.09
-  "Persistant animation can have a different frame interval."
+(defcustom parrot-persistent-animation-frame-interval 0.09
+  "Persistent animation can have a different frame interval."
   :type 'float
   :set (lambda (sym val)
 	 (set-default sym val) 
@@ -100,7 +100,7 @@
 (defun parrot-set-animation-frame-interval ()
   (interactive)
   (setq parrot-temp-animation-frame-interval parrot-animation-frame-interval
-	parrot-animation-frame-interval parrot-persistant-animation-frame-interval))
+	parrot-animation-frame-interval parrot-persistent-animation-frame-interval))
 
 (defun parrot-reset-animation-frame-interval ()
   (interactive)


### PR DESCRIPTION
with these changes we can accomplish:
* persistent animation
* customizable speed for persistent animation
* during parrot-party, execution of parrot-start-animation from hooks will pause the party mode config and use original config 
** e.g. original interval is 0.045, persistent interval is 0.09, and there is a on-save hook for parrot-start-animation; when C-x C-s is called, the parrot runs at 0.045 for parrot-num-rotations before reverting to persisting at 0.09